### PR TITLE
rtefcst now uses units for unit conversions/defaults

### DIFF
--- a/python/sl/lib/units.py
+++ b/python/sl/lib/units.py
@@ -68,6 +68,8 @@ def convert_units(v, new_units):
         for (possible_units, _, _) in _all_units:
             if cur_units in possible_units:
                 return _convert(v, possible_units, cur_units, new_units)
+        else:
+            raise ValueError("No units found so convertion doesn't make sense")
     else:
         raise ValueError("No units found so convertion doesn't make sense")
 
@@ -98,3 +100,57 @@ def normalize_variables(dataset):
     for k, v in dataset.variables.iteritems():
         normalize_units(v)
     return dataset
+
+
+def convert_scalar(s, cur_units, new_units):
+    """
+    Converts a single scalar from cur_units to new_units.
+    """
+    for (possible_units, __, __) in _all_units:
+        if cur_units in possible_units:
+            s *= (possible_units[cur_units] / possible_units[new_units])
+            return s
+    else:
+        raise ValueError("Current unit '%s' not found in %s" % (cur_units,
+                         __file__))
+
+
+def default_units(cur_units):
+    """
+    Returns a string with the default units for cur_units or None if no
+    matching default units are found.
+    """
+    for (possible_units, default, __) in _all_units:
+        if cur_units in possible_units:
+            return default
+    else:
+        return None
+
+
+def  normalize_scalar(s, cur_units):
+    """
+    Converts scalar from cur_units to default units. Returns a tuple
+    (normalized value, default unit). Raises ValueError if no matching default
+    units are found for cur_units.
+    """
+    default = default_units(cur_units)
+    if default:
+        return convert_scalar(s, cur_units, default), default
+    else:
+        raise ValueError("No matching default unit found for '%s'" % cur_units)
+
+
+def convert_from_default(s, new_units):
+    """
+    Converts scalar s from default units to new_units and returns the
+    result.  Raises ValueError if no matching default unit is found for
+    new_units.
+    """
+    default = default_units(new_units)
+    if default:
+        return convert_scalar(s, default, new_units)
+
+    else:
+        raise ValueError("No matching default unit found for '%s'" %
+                new_units)
+


### PR DESCRIPTION
Adds some conversion utilities to units.py to handle scalars, changes
conversions in rtefcst to use units.py for all conersions. Internally,
wind speeds, boat speeds, etc will be stroed in whatever is defined as
default in units.py
