### PR TITLE
Small fix to netCDF handler in slocum.py

### DIFF
--- a/python/slocum.py
+++ b/python/slocum.py
@@ -34,7 +34,9 @@ def handle_netcdf(args):
     """
     tinyfcst = zlib.decompress(args.input.read())
     fcst = tinylib.from_beaufort(tinyfcst)
-    fcst.dump(args.output)
+    out_file = args.output.name
+    args.output.close()
+    fcst.dump(out_file)
 
 
 def handle_grib(args):


### PR DESCRIPTION
`Dataset.dump()` needs file name rather than file object (perhaps worth changing in ``xray` to accept both?).
